### PR TITLE
Leave existing files in karma files array at the array's beginning

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,20 +51,22 @@ function prefix(shortName){
 //This is where the magic happens! Params injected automatically by karma
 function framework(files, ngConfig){
   if(!files) throw new Error('Your karma config must contain a files array');
+  var angularFiles = []; // Work on angular files separately to avoid missing with other modules in karma files array
   var added = {};
   if( Array.isArray(ngConfig) ) {
     // handle the array input
     ngConfig.forEach(function(file){
-      addFile(file, files, added, true);
+      addFile(file, angularFiles, added, true);
     });
   } else {
     // scan package.json for matching angular-* dependencies
     var pkg = require(path.resolve(__dirname, process.cwd(),'package.json'));
     ['devDependencies', 'peerDependencies', 'dependencies'].forEach(function(prop){
-      if(pkg[prop]) addFiles(files, Object.keys(pkg[prop]), added);
+      if(pkg[prop]) addFiles(angularFiles, Object.keys(pkg[prop]), added);
     });
   }
-  files.unshift(karmaFilePattern('angular'));   //always unshift angular last (so it's first!).
+  angularFiles.unshift(karmaFilePattern('angular'));   //always unshift angular last (so it's first!).
+  files.push.apply(files, angularFiles); // Add angular modules to files
 }
 framework.$inject = ['config.files', 'config.angular'];
 module.exports = {'framework:angular': ['factory', framework]};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Simplifies getting angular tests running on karma",
   "main": "index.js",
   "scripts": {
-    "test": "istanbul cover _mocha && npm run example && jshint index.js test/*.js",
+    "test": "istanbul cover \"../mocha/bin/_mocha\" && npm run example && jshint index.js test/*.js",
     "example": "cd example && npm i -D .. && npm i && ./node_modules/karma/bin/karma start",
     "coveralls": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
   },

--- a/test/framework.js
+++ b/test/framework.js
@@ -176,4 +176,11 @@ describe('framework',function(){
       framework();
     }).to.throw(/karma config must contain/);
   });
+
+  it('will not mess with existing entries in files', function() {
+    files = ['something-else-in-files-array'];
+    framework(files, ['angular-route', 'angular-mocks']);
+    expect(files.shift()).to.eql('something-else-in-files-array');
+    sortedEquals('angular-mocks','angular-route');
+  });
 });


### PR DESCRIPTION
As mentioned in #1, karma-angular currently puts the angular-mocks reference at the beginning of the files array, moving it before the test frameworks that are loaded. In these cases angular-mocks does not expose angular.mock.inject and angular.mock.module

I've fixed this and one other small issue in this pull request. There are 3 commits included:
1. Change package.json so that the test script runs on my machine (windows)
2. Add a test that checks for file order
3. Change the module so it passes the test by working on a separate files array and appending it to the karma files array, instead of working on the karma files array itself.
