### PR TITLE
Inspection of modules dist directory, additions to whitelist

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,14 +18,17 @@ var whitelist = [
 ];
 
 var path = require('path');
+var fs = require('fs');
 
 //only files matching this regex will be added.
 var regex = /^angular-[a-z]+$/;
 
 // Files from npm aren't going to change often enough to warrant watching them.
-var karmaFilePattern = function(file) {
-  file =  path.join(process.cwd(), 'node_modules', file, file + '.js');
-  return {pattern: file, included: true, served: true, watched: false};
+var karmaFilePattern = function(module) {
+  var file =  path.join(process.cwd(), 'node_modules', module, module + '.js');
+    if (!fs.existsSync(file)) {
+      file =  path.join(process.cwd(), 'node_modules', module, 'dist', module + '.js');
+    }  return {pattern: file, included: true, served: true, watched: false};
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -14,7 +14,10 @@ var whitelist = [
   'angular-mocks',
   'angular-resource',
   'angular-route',
-  'angular-touch'
+  'angular-touch',
+  'angular-material',
+  'angular-moment',
+  'angular-sanitize'
 ];
 
 var path = require('path');


### PR DESCRIPTION
The `karmaFilePattern()` functions looks for the module file at the root of the module directory. Some modules actually have it inside the `dist` directory, so i have added an additional step of looking for it there in case it is now found at root.

This is not perfect and might still fail. My first approach was looking at `package.json` , which is the proper way to do it, but i have found that some modules actually use gulp/node for their build process and refer to a file that contains a `require()` of the actual module file, which in turn makes karma fail upon text execution. As such, i have left that option out from this pull request, but please let me know what you think.

I also added the following modules to the whitelist:
- angular-material
- angular-moment
- angular-sanitize
